### PR TITLE
Add optional argument to provide the name of the required argument

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,11 @@
-function required(){
+function required(argumentName){
 	const funcName = required.caller.name ? `"${required.caller.name}"` : "<anonymous function>";
-
-	throw new Error(`Missing argument in function ${funcName}`);
+	let exception = 'Missing argument ';
+	if (argumentName) {
+		exception += `${argumentName} `;
+	}
+	exception += `in function ${funcName}`;
+	throw new Error(exception);
 }
 
 module.exports = required;

--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@ function required(argumentName){
 	const funcName = required.caller.name ? `"${required.caller.name}"` : "<anonymous function>";
 	let exception = 'Missing argument ';
 	if (argumentName) {
-		exception += `${argumentName} `;
+		exception += `"${argumentName}" `;
 	}
 	exception += `in function ${funcName}`;
 	throw new Error(exception);

--- a/test/index.js
+++ b/test/index.js
@@ -12,6 +12,14 @@ describe('required-argument:', function(){
             expect(test).to.throw(/myfunc/);
         });
 
+        it('should include the parameter name where provided', function() {
+            function myfunc(a = req('argumentName')){};
+            function test() { myfunc() };
+
+            expect(test).to.throw(Error);
+            expect(test).to.throw(/argumentName/);
+        });
+
         context('with 1 argument', function(){
             it('should throw an error when argument is not passed', function(){
                 function myfunc(a = req()){};


### PR DESCRIPTION
The function will now take an optional parameter to indicate the name of the required argument. This name, if provided, will be shown in the thrown Exception.

Example use:

``` JavaScript
const required = require('required-argument');

function myFunc(a = required('a')){
  // do stuff
}

myFunc(); // Error: Missing argument "a" in function "myfunc"
```
